### PR TITLE
Fix breaking change w/ Gradle dependencies 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.15.+'
+    implementation 'com.facebook.react:react-native:0.15.+'
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-android-shared-preferences",
   "description": "A react native android package to access SharedPreferences.",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "main": "index.android.js",
   "keywords": [
     "react-component",


### PR DESCRIPTION
## Intent
This fixes a breaking API change with the Android Gradle plugin, which was deprecated as of version 3.0.0 and later made obsolete. 

## Changes
When adding Gradle dependencies, the `compile` command has been removed and replaced with `implementation`/`api`.

## More information
- [Gradle support docs](https://docs.gradle.org/5.4.1/userguide/java_library_plugin.html#sec:java_library_separation)
- [Android deprecation doc](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations)